### PR TITLE
Use URL() instead Regexp on protocol

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -5,6 +5,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
 */
  
+const HTTP_PROTOCOL="http:"
+const HTTPS_PROTOCOL="https:"
+
 var httpObject = config.http.object, httpsObject = config.https.object;
 
 window.setTimeout(function () {
@@ -169,7 +172,7 @@ var errorHandler = function (error, details, force, host) {
             window.setTimeout(function () {
               app.tabQuery(details, function (tab) {
                 if (tab) {
-                  if (force || /^https:\/\//i.test(details.url)) {
+                  if (force || new URL(details.url).protocol==HTTPS_PROTOCOL) {
                     config.http.proxy[domain].error = true;
                     config.http.proxy[domain].incognito = tab.incognito;
                     config.http.object = httpObject;
@@ -211,7 +214,7 @@ var handleExtraErrors = function (top, details) {
             else callback({"error": ('net::ERR_XHR_STATUS_' + xhr.status), "details": xhr._details});
           }
           else { /* if the response URL is HTTP, we still have the error */
-            if (/^http:\/\//i.test(xhr.responseURL)) callback({"error": 'net::ERR_XHR_REDIRECT', "details": xhr._details});
+            if (new URL(xhr.responseURL).protocol==HTTP_PROTOCOL) callback({"error": 'net::ERR_XHR_REDIRECT', "details": xhr._details});
             else callback({"error": '', "details": xhr._details});
           }
         }
@@ -234,9 +237,12 @@ var handleExtraErrors = function (top, details) {
 };
 
 app.onBeforeRequest(function (details) {
-  var top = details.url;
-  if (/^http:\/\//i.test(top)) {
-    var newURL = top.replace(/^http:\/\//i, 'https://');
+  let top = details.url;
+  let urlObj=new URL(details.url);
+  if (urlObj.protocol==HTTP_PROTOCOL) {
+    urlObj.protocol=HTTPS_PROTOCOL;
+    let newURL= urlObj.toString();
+    // var newURL = top.replace(/^http:\/\//i, 'https://');
     httpObject = config.http.object;
     httpsObject = config.https.object;
     var domain = app.toHostname(top);
@@ -259,7 +265,8 @@ app.onBeforeRequest(function (details) {
 
 app.onHeadersReceived(function (domain, details) {
   if (config.addon.typemissmatch) {
-    if (/^http:\/\//i.test(details.url)) {
+    let urlObj=new URL(details.url);
+    if (urlObj.protocol==HTTP_PROTOCOL) {
       if (config.http.proxy[domain]) {
         if (!config.http.proxy[domain].error) {
           errorHandler("net::ERR_TYPE_MISMATCH", details, true, domain);
@@ -272,6 +279,7 @@ app.onHeadersReceived(function (domain, details) {
 app.onCompleted(function (e) {
   var _check = function (details) {
     var top = details.url;
+    let urlObj=new URL(details.url);
     var domain = app.toHostname(top);
     var msg1 = " - HTTPS is OK (" + domain + "), cleaning whitelist table";
     var msg2 = " - HTTPS had Error (" + domain + "), but removed from whitelist because whitelisting is disabled";
@@ -289,7 +297,7 @@ app.onCompleted(function (e) {
     httpsObject = config.https.object;
     if (config.http.proxy[domain]) {
       if (!details.error || config.https.proxy[domain]) {
-        var flag = /^https:\/\//i.test(details.url) && !config.http.proxy[domain].error;
+        var flag = urlObj.protocol==HTTPS_PROTOCOL && !config.http.proxy[domain].error;
         if (flag) _clean(domain, msg1);
         else if (config.addon.dwhitelisting) _clean(domain, msg2);
         else if (config.http.proxy[domain].incognito && config.addon.incognito) _clean(domain, msg4);


### PR DESCRIPTION
Use URL() instead Regexp on protocol and besides.I think may be it can cache hostname which pass regexp  test to avoid using regexp every time,I'll try it when I have time.